### PR TITLE
Add a user agent string to the NPS API request

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -69,7 +69,8 @@ function getJsonFromNPS(park, eventCallback) {
       path: '/api/v0/parks?parkCode=' + park,
       method: 'GET',
       headers: {
-        'Authorization': NPS_API_KEY
+        'Authorization': NPS_API_KEY,
+        'User-Agent': 'Node/NPS-Alexa-Skill (1.0)'
       }
     };
 


### PR DESCRIPTION
Experimenting with calls to the NPS API I discovered that adding a User-Agent header was required to get a 200 OK from the service. I haven't tested this code, but it should fix the problem with the NPS API returning a 500.